### PR TITLE
Readme: Prefix ng  command with npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 # How to Run
 
 1. Download / Clone the project
-2. Open a terminal and navigate to the project folder. Run `npm i` and then `ng serve`, and open your favorite browser to `http://localhost:4200/`
+2. Open a terminal and navigate to the project folder. Run `npm i` and then `npx ng serve`, and open your favorite browser to `http://localhost:4200/`
 3. Place your Giphy API key inside of the top text field.
 4. Open your console and watch as the 'search' endpoint works flawlessly, but 'termSuggestions' does not!


### PR DESCRIPTION
Originally, `ng serve` assumes that `ng` is installed globally. 
By running `npx` before `ng` npm runs it from your local installation.